### PR TITLE
Add and update to Python 3.11 where appropriate

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           path: ./dist/*.tar.gz
 
-  build_wheels:
+  build_wheel:
     name: Build wheel
     runs-on: ubuntu-latest
     steps:
@@ -126,7 +126,7 @@ jobs:
       - typecheck
       - test
       - build_source_dist
-      - build_wheels
+      - build_wheel
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -111,11 +111,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.1
+      - name: Install build
+        run: python -m pip install build
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheels
+        run: pyproject-build --wheel --outdir wheels
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-python@v4.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install tox
         run: python -m pip install tox
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v4.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install tox
         run: python -m pip install tox
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-python@v4.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install tox
         run: python -m pip install tox
@@ -58,6 +58,8 @@ jobs:
     strategy:
       matrix:
         python:
+          - version: "3.11"
+            toxenv: "py311"
           - version: "3.10"
             toxenv: "py310"
           - version: "3.9"
@@ -83,7 +85,7 @@ jobs:
 
       - uses: actions/setup-python@v4.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install build
         run: python -m pip install build
@@ -107,7 +109,7 @@ jobs:
 
       - uses: actions/setup-python@v4.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.3.1

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -98,12 +98,8 @@ jobs:
           path: ./dist/*.tar.gz
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
-
+    name: Build wheel
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py39', 'py310']
+target-version = ['py39', 'py310', 'py311']


### PR DESCRIPTION
## Description of issue

Some processes are intended to use the latest available Python version, but they were still using Python 3.10. Others are meant to use all supported Python versions and weren't including Python 3.11.

## Description of solution

Add Python 3.11 and update to it where appropriate.

## Additional context

Fix wheel build because this package is a pure Python package.