### PR TITLE
Fix Read the Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+  commands:
+    - pip install tox
+    - tox -e docs -- _readthedocs/html/
 
 python:
   install:

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ First, make an `OPENAI_API_KEY` environment variable available whose value is yo
 {..., 'choices': [{'text': '\n\nMy quest is to find my purpose and fulfill it.', ...}], ...}}
 ```
 
-See the package documentation for the full list of available endpoints, and see [the OpenAI documentation](https://beta.openai.com/docs/api-reference/introduction) for the accepted/required parameters to each endpoint.
+See the [package documentation](https://openaiapi.readthedocs.io) for the full list of available endpoints, and see [the OpenAI documentation](https://beta.openai.com/docs/api-reference/introduction) for the accepted/required parameters to each endpoint.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,8 +63,8 @@ html_static_path = ['_static']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "apiron": ("https://apiron.readthedocs.org/en/latest/", None),
-    "requests": ("https://docs.python-requests.org/en/master/", None),
+    "apiron": ("https://apiron.readthedocs.io/en/latest/", None),
+    "requests": ("https://docs.python-requests.org/en/latest/", None),
     "urllib3": ("https://urllib3.readthedocs.io/en/latest/", None),
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,9 +105,9 @@ commands =
         --implicit-namespaces \
         --module-first \
         --separate \
-        -o docs/reference/ \
+        -o {posargs:docs}/reference/ \
         src/openaiapi/
-    sphinx-build -W --keep-going -b html docs/ docs/_build/
+    sphinx-build -W --keep-going -b html docs/ {posargs:docs/_build/}
 
 [testenv:devdocs]
 deps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ commands =
         --implicit-namespaces \
         --module-first \
         --separate \
-        -o {posargs:docs}/reference/ \
+        -o docs/reference/ \
         src/openaiapi/
     sphinx-build -W --keep-going -b html docs/ {posargs:docs/_build/}
 


### PR DESCRIPTION
## Description of issue

The build on Read the Docs wasn't using the `docs` tox environment to build the docs

## Description of solution

Update the config for tox and Read the Docs to play nicely
